### PR TITLE
add vertex itself to nodes' neighborhood in PSCAN

### DIFF
--- a/operators/src/main/scala/ml/sparkling/graph/operators/algorithms/community/pscan/PSCAN.scala
+++ b/operators/src/main/scala/ml/sparkling/graph/operators/algorithms/community/pscan/PSCAN.scala
@@ -20,6 +20,7 @@ case object PSCAN extends CommunityDetectionAlgorithm{
   def computeConnectedComponents[VD:ClassTag,ED:ClassTag](graph:Graph[VD,ED],epsilon:Double=0.05):Graph[ComponentID,ED]={
 
     val neighbours: Graph[NeighbourSet, ED] = NeighboursUtils.getWithNeighbours(graph,treatAsUndirected = true)
+        .mapVertices((vid, neighbours)=> neighbours.add(vid))
 
     val edgesWithSimilarity=neighbours.mapTriplets(edge=>{
       val sizeOfIntersection=intersectSize(edge.srcAttr,edge.dstAttr)


### PR DESCRIPTION
the neighborhood of each node in PSCAN should cantain itself.